### PR TITLE
feat(at-rules-require-postcss): add rule

### DIFF
--- a/src/rules/at-rules-require-postcss/rule.test.ts
+++ b/src/rules/at-rules-require-postcss/rule.test.ts
@@ -1,0 +1,27 @@
+
+import { RuleTester } from 'eslint';
+import svelteParser from 'svelte-eslint-parser';
+
+import rule from './rule';
+
+const tester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    parser: svelteParser,
+    sourceType: 'module'
+  }
+});
+
+const ERROR = { message: 'Using \'{{atRule}}\' requires setting style lang to postcss' };
+
+tester.run('no-literal-mustache-mix', rule, {
+  invalid: [
+    {
+      code: `<style lang="postcss">.foo { .foo { @apply px-8; } }</style>`,
+      errors: [ERROR]
+    }
+  ],
+  valid: [
+    { code: '' }
+  ]
+});

--- a/src/rules/at-rules-require-postcss/rule.ts
+++ b/src/rules/at-rules-require-postcss/rule.ts
@@ -1,0 +1,32 @@
+import { createNamedRule } from '../../utils';
+
+export type OptionList = [];
+// Fill this type with the message ids
+export type MessageIds = 'require-postcss';
+
+export default createNamedRule<OptionList, MessageIds>({
+  create(_context) {
+    return {
+      SvelteStyleElement(node) {
+        console.log(node);
+      }
+    };
+  },
+  defaultOptions: [
+    // Configure here the default options, if any
+  ],
+  meta: {
+    docs: {
+      description: 'undefined'
+    },
+    messages: {
+      'require-postcss': 'Using \'{{atRule}}\' requires setting style lang to postcss'
+    },
+    schema: [{
+      properties: {},
+      type: 'object'
+    }],
+    type: 'suggestion'
+  },
+  name: 'at-rules-require-postcss'
+});


### PR DESCRIPTION
Adds a new `at-rules-require-postcss` rule to the plugin.

> In order to have this rule working faster, it is needed to have
> `svelte-eslint-parser` to parse `<style>` tags as `svelte/compiler` does.
> Currently, `<style>` tags are not being parsed accordingly:
> https://github.com/sveltejs/svelte-eslint-parser/issues/594
